### PR TITLE
로그인 작업

### DIFF
--- a/api-module/src/main/java/com/koa/apimodule/ApiModuleApplication.java
+++ b/api-module/src/main/java/com/koa/apimodule/ApiModuleApplication.java
@@ -2,8 +2,11 @@ package com.koa.apimodule;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {UserDetailsServiceAutoConfiguration.class })
+@ComponentScan(basePackages = "com.koa")
 public class ApiModuleApplication {
 
     public static void main(String[] args) {

--- a/api-module/src/main/java/com/koa/apimodule/auth/security/JWTAuthenticationToken.java
+++ b/api-module/src/main/java/com/koa/apimodule/auth/security/JWTAuthenticationToken.java
@@ -1,0 +1,22 @@
+package com.koa.apimodule.auth.security;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+
+public class JWTAuthenticationToken extends AbstractAuthenticationToken {
+    private String email;
+    public JWTAuthenticationToken(String email) {
+        super(null);
+        this.email=email;
+        setAuthenticated(true);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return email;
+    }
+}

--- a/api-module/src/main/java/com/koa/apimodule/auth/security/SecurityConfig.java
+++ b/api-module/src/main/java/com/koa/apimodule/auth/security/SecurityConfig.java
@@ -1,0 +1,37 @@
+package com.koa.apimodule.auth.security;
+
+import com.koa.apimodule.auth.security.filter.JWTAuthenticationFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain chain(HttpSecurity http) throws Exception {
+        http.cors().disable();
+
+        http.addFilterBefore(SecurityHandler.getJWTAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(SecurityHandler.getJWTEntryPoint(), JWTAuthenticationFilter.class);
+
+        http.csrf().disable();
+
+        http.authorizeHttpRequests(request -> {
+            request.requestMatchers("/h2-console/**").permitAll();
+            request.anyRequest().permitAll(); // 다른 요청은 모두 허용
+        });
+        http.formLogin().disable();
+        http.httpBasic().disable();
+        http.logout().disable();
+        http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+        http.headers().frameOptions().disable();
+
+        return http.build();
+    }
+
+}

--- a/api-module/src/main/java/com/koa/apimodule/auth/security/SecurityHandler.java
+++ b/api-module/src/main/java/com/koa/apimodule/auth/security/SecurityHandler.java
@@ -1,0 +1,24 @@
+package com.koa.apimodule.auth.security;
+
+import com.koa.apimodule.auth.security.filter.JWTAuthenticationFilter;
+import com.koa.apimodule.auth.security.filter.JWTEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SecurityHandler {
+    private static JWTAuthenticationFilter jwtAuthenticationFilter;
+    private static JWTEntryPoint jwtEntryPoint;
+
+    public SecurityHandler(JWTAuthenticationFilter jwtAuthenticationFilter, JWTEntryPoint jwtEntryPoint) {
+        SecurityHandler.jwtAuthenticationFilter = jwtAuthenticationFilter;
+        SecurityHandler.jwtEntryPoint = jwtEntryPoint;
+    }
+
+    public static JWTAuthenticationFilter getJWTAuthenticationFilter(){
+        return jwtAuthenticationFilter;
+    }
+
+    public static JWTEntryPoint getJWTEntryPoint(){
+        return jwtEntryPoint;
+    }
+}

--- a/api-module/src/main/java/com/koa/apimodule/auth/security/filter/JWTAuthenticationFilter.java
+++ b/api-module/src/main/java/com/koa/apimodule/auth/security/filter/JWTAuthenticationFilter.java
@@ -1,0 +1,75 @@
+package com.koa.apimodule.auth.security.filter;
+
+import com.koa.apimodule.auth.security.JWTAuthenticationToken;
+import com.koa.coremodule.auth.application.common.consts.AuthConsts;
+import com.koa.coremodule.auth.application.common.consts.IgnoredPathConsts;
+import com.koa.coremodule.auth.application.service.JWTExtractEmailUseCase;
+import com.koa.coremodule.auth.application.service.JWTExtractTokenUseCase;
+import com.koa.coremodule.auth.application.service.JWTVerifyUseCase;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class JWTAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JWTVerifyUseCase jwtVerifyUseCase;
+    private final JWTExtractEmailUseCase jwtExtractEmailUseCase;
+    private final JWTExtractTokenUseCase jwtExtractTokenUseCase;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        if(!isIgnoredPath(request)){
+            final String tokenHeaderValue = getTokenFromHeader(request);
+            final String accessToken = jwtExtractTokenUseCase.extractToken(tokenHeaderValue);
+            jwtVerifyUseCase.validateToken(accessToken);
+            final String email = jwtExtractEmailUseCase.extractEmail(accessToken);
+            initAuthentication(new JWTAuthenticationToken(email));
+        }
+        filterChain.doFilter(request, response);
+    }
+
+
+    private String getTokenFromHeader(HttpServletRequest request){
+        String header = request.getHeader(AuthConsts.AUTHORIZATION);
+        return StringUtils.hasText(header)? header : AuthConsts.EMPTY_HEADER;
+    }
+
+    private Boolean isIgnoredPath(HttpServletRequest request){
+        final Set<String> ignoredPathURI = IgnoredPathConsts.getIgnoredPath().keySet();
+        return ignoredPathURI.stream()
+                .anyMatch(ignoredPath -> isMatchingPath(request, ignoredPath)&&isMatchingMethod(request, ignoredPath));
+    }
+
+    private Boolean isMatchingPath(HttpServletRequest request, String ignoredPathURI){
+        final AntPathMatcher antPathMatcher = new AntPathMatcher();
+        return antPathMatcher.matchStart(ignoredPathURI, request.getRequestURI());
+    }
+
+    private Boolean isMatchingMethod(HttpServletRequest request, String ignoredPathURI) {
+        Set<HttpMethod> allowedMethods = IgnoredPathConsts.getIgnoredPath().get(ignoredPathURI);
+        if (allowedMethods != null) {
+            HttpMethod requestMethod = HttpMethod.valueOf(request.getMethod());
+            return allowedMethods.contains(requestMethod);
+        }
+        return false;
+    }
+
+    private void initAuthentication(final Authentication authentication){
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+}

--- a/api-module/src/main/java/com/koa/apimodule/auth/security/filter/JWTEntryPoint.java
+++ b/api-module/src/main/java/com/koa/apimodule/auth/security/filter/JWTEntryPoint.java
@@ -1,0 +1,36 @@
+package com.koa.apimodule.auth.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.koa.commonmodule.exception.BusinessException;
+import com.koa.commonmodule.exception.ErrorResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JWTEntryPoint extends OncePerRequestFilter {
+    private final ObjectMapper objectMapper;
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try{
+            filterChain.doFilter(request, response);
+        } catch (BusinessException exception){
+            handleException(response, exception);
+        }
+    }
+
+    private void handleException(HttpServletResponse response, BusinessException exception) throws IOException {
+        ErrorResponse errorResponse = ErrorResponse.from(exception);
+        response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/api-module/src/main/java/com/koa/apimodule/command/api/AuthController.java
+++ b/api-module/src/main/java/com/koa/apimodule/command/api/AuthController.java
@@ -1,0 +1,26 @@
+package com.koa.apimodule.command.api;
+
+import com.koa.coremodule.auth.application.dto.AuthResponse;
+import com.koa.coremodule.auth.application.service.AuthUseCase;
+import com.koa.coremodule.auth.domain.jwt.JWTProvider;
+import com.koa.coremodule.member.domain.entity.Authority;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+
+
+    private final AuthUseCase authUseCase;
+    private final JWTProvider jwtProvider;
+
+    @GetMapping("/login/{authority}")
+    public AuthResponse authLogin(@PathVariable Authority authority, @RequestParam String email, @RequestParam String password){
+        return authUseCase.authLogin(authority, email, password);
+    }
+
+}

--- a/api-module/src/main/resources/application-local.yml
+++ b/api-module/src/main/resources/application-local.yml
@@ -20,6 +20,12 @@ spring:
           auto: none
         show_sql: true
 
+jwt:
+  secret: Thisistheattendanceappserviceforthekusitmsconferenceandthisisaverylongsecertkey
+  access-token-expiration-time: 86400000 #  24*60*60*1000 = 1일
+  refresh-token-expiration-time: 604800000 # 7*24*60*60*1000 = 7일
+
+
 logging:
   level:
     org:

--- a/common-module/build.gradle
+++ b/common-module/build.gradle
@@ -5,6 +5,7 @@ plugins {
 dependencies {
     testFixturesImplementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     testFixturesImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 }
 
 bootJar {

--- a/common-module/src/main/java/com/koa/commonmodule/utils/SecurityUtils.java
+++ b/common-module/src/main/java/com/koa/commonmodule/utils/SecurityUtils.java
@@ -1,0 +1,14 @@
+package com.koa.commonmodule.utils;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SecurityUtils {
+
+    public static String getAuthenticationPrincipal() {
+        final String email = (String) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return email;
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/auth/application/common/consts/AuthConsts.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/application/common/consts/AuthConsts.java
@@ -1,0 +1,11 @@
+package com.koa.coremodule.auth.application.common.consts;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class AuthConsts {
+    public static final String AUTHENTICATION_TYPE= "Bearer";
+    public static final String AUTHORIZATION = "Authorization";
+    public static final String EMPTY_HEADER = null;
+}

--- a/core-module/src/main/java/com/koa/coremodule/auth/application/common/consts/IgnoredPathConsts.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/application/common/consts/IgnoredPathConsts.java
@@ -1,0 +1,22 @@
+package com.koa.coremodule.auth.application.common.consts;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpMethod;
+
+import java.util.Map;
+import java.util.Set;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class IgnoredPathConsts {
+
+    @Getter
+    private static Map<String, Set<HttpMethod>> ignoredPath = Map.of(
+            "/docs/**", Set.of(HttpMethod.GET),
+            "/oauth/**", Set.of(HttpMethod.GET),
+            "/h2-console/**", Set.of(HttpMethod.GET, HttpMethod.POST),
+            "/auth/login/**", Set.of(HttpMethod.GET)
+    );
+
+}

--- a/core-module/src/main/java/com/koa/coremodule/auth/application/dto/AuthRequest.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/application/dto/AuthRequest.java
@@ -1,0 +1,13 @@
+package com.koa.coremodule.auth.application.dto;
+
+import com.koa.coremodule.member.domain.entity.Authority;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AuthRequest {
+    private Authority authority;
+    private String email;
+    private String password;
+}

--- a/core-module/src/main/java/com/koa/coremodule/auth/application/dto/AuthResponse.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/application/dto/AuthResponse.java
@@ -1,0 +1,13 @@
+package com.koa.coremodule.auth.application.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class AuthResponse {
+    private final String accessToken;
+    private final String refreshToken;
+}

--- a/core-module/src/main/java/com/koa/coremodule/auth/application/exception/AuthException.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/application/exception/AuthException.java
@@ -1,0 +1,10 @@
+package com.koa.coremodule.auth.application.exception;
+
+import com.koa.commonmodule.exception.BusinessException;
+import com.koa.commonmodule.exception.Error;
+
+public class AuthException extends BusinessException {
+    public AuthException(Error error) {
+        super(error);
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/auth/application/exception/InvalidAuthorizationTypeException.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/application/exception/InvalidAuthorizationTypeException.java
@@ -1,0 +1,7 @@
+package com.koa.coremodule.auth.application.exception;
+import com.koa.commonmodule.exception.Error;
+public class InvalidAuthorizationTypeException extends AuthException {
+    public InvalidAuthorizationTypeException(Error error) {
+        super(error);
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/auth/application/service/AuthUseCase.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/application/service/AuthUseCase.java
@@ -1,0 +1,19 @@
+package com.koa.coremodule.auth.application.service;
+
+import com.koa.commonmodule.annotation.ApplicationService;
+import com.koa.coremodule.auth.application.dto.AuthRequest;
+import com.koa.coremodule.auth.application.dto.AuthResponse;
+import com.koa.coremodule.auth.application.service.command.AuthInvoker;
+import com.koa.coremodule.member.domain.entity.Authority;
+import lombok.RequiredArgsConstructor;
+
+
+@ApplicationService
+@RequiredArgsConstructor
+public class AuthUseCase {
+    private final AuthInvoker oAuthInvoker;
+
+    public AuthResponse authLogin(Authority authority, String email, String password){
+        return oAuthInvoker.execute(new AuthRequest(authority, email, password));
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/auth/application/service/JWTExtractEmailUseCase.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/application/service/JWTExtractEmailUseCase.java
@@ -1,0 +1,15 @@
+package com.koa.coremodule.auth.application.service;
+
+import com.koa.commonmodule.annotation.ApplicationService;
+import com.koa.coremodule.auth.domain.jwt.JWTProvider;
+import lombok.RequiredArgsConstructor;
+
+@ApplicationService
+@RequiredArgsConstructor
+public class JWTExtractEmailUseCase {
+    private final JWTProvider jwtProvider;
+
+    public String extractEmail(final String token){
+        return jwtProvider.extractEmailFromAccessToken(token);
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/auth/application/service/JWTExtractTokenUseCase.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/application/service/JWTExtractTokenUseCase.java
@@ -1,0 +1,26 @@
+package com.koa.coremodule.auth.application.service;
+
+import com.koa.commonmodule.annotation.ApplicationService;
+import com.koa.commonmodule.exception.Error;
+import com.koa.coremodule.auth.application.common.consts.AuthConsts;
+import com.koa.coremodule.auth.application.exception.InvalidAuthorizationTypeException;
+import org.springframework.util.StringUtils;
+
+import java.util.Objects;
+
+@ApplicationService
+public class JWTExtractTokenUseCase {
+    public String extractToken(final String tokenHeader) {
+        if(!StringUtils.hasText(tokenHeader)){
+            throw new InvalidAuthorizationTypeException(Error.EMPTY_AUTHORIZATION_HEADER);
+        }
+
+        final String[] splitToken = tokenHeader.split(" ");
+        final String authorizationType = splitToken[0];
+        final String accessToken = splitToken[1];
+        if(!Objects.equals(authorizationType, AuthConsts.AUTHENTICATION_TYPE)){
+            throw new InvalidAuthorizationTypeException(Error.INVALID_AUTHORIZATION_TYPE);
+        }
+        return accessToken;
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/auth/application/service/JWTVerifyUseCase.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/application/service/JWTVerifyUseCase.java
@@ -1,0 +1,15 @@
+package com.koa.coremodule.auth.application.service;
+
+import com.koa.commonmodule.annotation.ApplicationService;
+import com.koa.coremodule.auth.domain.jwt.JWTProvider;
+import lombok.RequiredArgsConstructor;
+
+@ApplicationService
+@RequiredArgsConstructor
+public class JWTVerifyUseCase {
+    private final JWTProvider jwtProvider;
+
+    public void validateToken(final String token){
+        jwtProvider.validateToken(token);
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/auth/application/service/command/AuthInvoker.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/application/service/command/AuthInvoker.java
@@ -1,0 +1,50 @@
+package com.koa.coremodule.auth.application.service.command;
+
+import com.koa.commonmodule.exception.Error;
+import com.koa.coremodule.auth.application.common.consts.AuthConsts;
+import com.koa.coremodule.auth.application.dto.AuthRequest;
+import com.koa.coremodule.auth.application.dto.AuthResponse;
+import com.koa.coremodule.auth.application.exception.AuthException;
+import com.koa.coremodule.auth.application.service.command.handler.AuthHandler;
+import com.koa.coremodule.auth.domain.jwt.JWTProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.function.Function;
+
+@Component
+@RequiredArgsConstructor
+public class AuthInvoker {
+    private final List<AuthHandler> authHandlerList;
+    private final JWTProvider jwtProvider;
+
+    private static final String AUTHENTICATION_TYPE = AuthConsts.AUTHENTICATION_TYPE + " ";
+
+    public AuthResponse execute(AuthRequest request){
+        String email = attemptLogin(request);
+        return generateServerAuthenticationTokens(email);
+    }
+
+    private String attemptLogin(AuthRequest request) {
+        for (AuthHandler authHandler : authHandlerList) {
+            if (authHandler.isAccessible(request)) {
+                return authHandler.handle(request);
+            }
+        }
+        throw new AuthException(Error.AUTH_FAIL);
+    }
+
+    private AuthResponse generateServerAuthenticationTokens(String email) {
+        final String accessToken = attachAuthenticationType(jwtProvider::generateAccessToken, email);
+        final String refreshToken = attachAuthenticationType(jwtProvider::generateRefreshToken, email);
+        return AuthResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    private <T> String attachAuthenticationType(Function<T, String> generateTokenMethod, T includeClaimData) {
+        return AUTHENTICATION_TYPE + generateTokenMethod.apply(includeClaimData);
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/auth/application/service/command/handler/AuthHandler.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/application/service/command/handler/AuthHandler.java
@@ -1,0 +1,9 @@
+package com.koa.coremodule.auth.application.service.command.handler;
+
+import com.koa.coremodule.auth.application.dto.AuthRequest;
+
+public interface AuthHandler {
+    String handle(AuthRequest authenticationInfo);
+
+    boolean isAccessible(AuthRequest authenticationInfo);
+}

--- a/core-module/src/main/java/com/koa/coremodule/auth/application/service/command/handler/impl/ExecutiveAuthHandler.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/application/service/command/handler/impl/ExecutiveAuthHandler.java
@@ -11,11 +11,11 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ExecutiveAuthHandler implements AuthHandler {
     private static final Authority AUTH_TYPE = Authority.EXECUTIVE;
-    private final MemberQueryService userQueryService;
+    private final MemberQueryService memberQueryService;
 
     @Override
     public String handle(AuthRequest authenticationInfo) {
-        userQueryService.checkAccountExist(authenticationInfo.getEmail(),authenticationInfo.getAuthority());
+        memberQueryService.checkAccountExist(authenticationInfo.getEmail(),authenticationInfo.getAuthority());
         return authenticationInfo.getEmail();
     }
 

--- a/core-module/src/main/java/com/koa/coremodule/auth/application/service/command/handler/impl/ExecutiveAuthHandler.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/application/service/command/handler/impl/ExecutiveAuthHandler.java
@@ -1,0 +1,28 @@
+package com.koa.coremodule.auth.application.service.command.handler.impl;
+
+import com.koa.coremodule.auth.application.dto.AuthRequest;
+import com.koa.coremodule.auth.application.service.command.handler.AuthHandler;
+import com.koa.coremodule.member.domain.entity.Authority;
+import com.koa.coremodule.member.domain.service.MemberQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ExecutiveAuthHandler implements AuthHandler {
+    private static final Authority AUTH_TYPE = Authority.EXECUTIVE;
+    private final MemberQueryService userQueryService;
+
+    @Override
+    public String handle(AuthRequest authenticationInfo) {
+        userQueryService.checkAccountExist(authenticationInfo.getEmail(),authenticationInfo.getAuthority());
+        return authenticationInfo.getEmail();
+    }
+
+    @Override
+    public boolean isAccessible(AuthRequest authenticationInfo) {
+        return AUTH_TYPE.equals(authenticationInfo.getAuthority());
+    }
+
+
+}

--- a/core-module/src/main/java/com/koa/coremodule/auth/application/service/command/handler/impl/MemberAuthHandler.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/application/service/command/handler/impl/MemberAuthHandler.java
@@ -11,11 +11,11 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class MemberAuthHandler implements AuthHandler {
     private static final Authority AUTH_TYPE = Authority.MEMBER;
-    private final MemberQueryService userQueryService;
+    private final MemberQueryService memberQueryService;
 
     @Override
     public String handle(AuthRequest authenticationInfo) {
-        userQueryService.checkAccountExist(authenticationInfo.getEmail(),authenticationInfo.getAuthority());
+        memberQueryService.checkAccountExist(authenticationInfo.getEmail(),authenticationInfo.getAuthority());
         return authenticationInfo.getEmail();
     }
 

--- a/core-module/src/main/java/com/koa/coremodule/auth/application/service/command/handler/impl/MemberAuthHandler.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/application/service/command/handler/impl/MemberAuthHandler.java
@@ -1,0 +1,29 @@
+package com.koa.coremodule.auth.application.service.command.handler.impl;
+
+import com.koa.coremodule.auth.application.dto.AuthRequest;
+import com.koa.coremodule.auth.application.service.command.handler.AuthHandler;
+import com.koa.coremodule.member.domain.entity.Authority;
+import com.koa.coremodule.member.domain.service.MemberQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberAuthHandler implements AuthHandler {
+    private static final Authority AUTH_TYPE = Authority.MEMBER;
+    private final MemberQueryService userQueryService;
+
+    @Override
+    public String handle(AuthRequest authenticationInfo) {
+        userQueryService.checkAccountExist(authenticationInfo.getEmail(),authenticationInfo.getAuthority());
+        return authenticationInfo.getEmail();
+    }
+
+    @Override
+    public boolean isAccessible(AuthRequest authenticationInfo) {
+        return AUTH_TYPE.equals(authenticationInfo.getAuthority());
+    }
+
+
+}
+

--- a/core-module/src/main/java/com/koa/coremodule/auth/domain/entity/Token.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/domain/entity/Token.java
@@ -1,0 +1,29 @@
+package com.koa.coremodule.auth.domain.entity;
+
+import com.koa.commonmodule.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Token extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "token_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private TokenType tokenType;
+
+    private String email;
+    private String tokenValue;
+
+    public static Token createToken(TokenType type, String email, String value){
+        return new Token(null, type, email, value);
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/auth/domain/entity/TokenType.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/domain/entity/TokenType.java
@@ -1,0 +1,9 @@
+package com.koa.coremodule.auth.domain.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum TokenType {
+    ACCESS_TOKEN,
+    REFRESH_TOKEN
+}

--- a/core-module/src/main/java/com/koa/coremodule/auth/domain/exception/NotExistTokenException.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/domain/exception/NotExistTokenException.java
@@ -1,0 +1,11 @@
+package com.koa.coremodule.auth.domain.exception;
+
+
+import com.koa.commonmodule.exception.Error;
+import com.koa.coremodule.auth.domain.jwt.exception.TokenException;
+
+public class NotExistTokenException extends TokenException {
+    public NotExistTokenException(Error error) {
+        super(error);
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/auth/domain/jwt/ConfigurationPropertiesConfig.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/domain/jwt/ConfigurationPropertiesConfig.java
@@ -1,0 +1,11 @@
+package com.koa.coremodule.auth.domain.jwt;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(JWTProperties.class)
+public class ConfigurationPropertiesConfig {
+}
+//JWTProperties 클래스는 @ConfigurationProperties 어노테이션을 사용하여 외부 속성 파일(application.yml 또는 application.properties)에서 값을 주입받아야
+//하기 때문에 Spring의 IoC 컨테이너에 등록되어야함.

--- a/core-module/src/main/java/com/koa/coremodule/auth/domain/jwt/JWTConsts.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/domain/jwt/JWTConsts.java
@@ -1,0 +1,11 @@
+package com.koa.coremodule.auth.domain.jwt;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class JWTConsts {
+    public static final String TOKEN_ISSUER = "koa";
+    public static final String EMAIL ="email";
+    public static final String TOKEN_TYPE = "token_type";
+}

--- a/core-module/src/main/java/com/koa/coremodule/auth/domain/jwt/JWTProperties.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/domain/jwt/JWTProperties.java
@@ -1,0 +1,15 @@
+package com.koa.coremodule.auth.domain.jwt;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@RequiredArgsConstructor
+//jwt 프리픽스로 시작하는 속성 값들이 JWTProperties 클래스의 필드에 주입
+@ConfigurationProperties(prefix = "jwt")
+public class JWTProperties {
+    private final String secret;
+    private final long accessTokenExpirationTime;
+    private final long refreshTokenExpirationTime;
+}

--- a/core-module/src/main/java/com/koa/coremodule/auth/domain/jwt/JWTProvider.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/domain/jwt/JWTProvider.java
@@ -1,0 +1,136 @@
+package com.koa.coremodule.auth.domain.jwt;
+
+import com.koa.commonmodule.exception.Error;
+import com.koa.coremodule.auth.domain.entity.TokenType;
+import com.koa.coremodule.auth.domain.jwt.exception.ExpiredTokenException;
+import com.koa.coremodule.auth.domain.jwt.exception.InvalidTokenException;
+import com.koa.coremodule.auth.domain.service.TokenQueryService;
+import com.koa.coremodule.auth.domain.service.TokenSaveService;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class JWTProvider {
+    private final JWTProperties jwtProperties;
+    private final TokenSaveService tokenSaveService;
+    private final TokenQueryService tokenQueryService;
+
+    /**
+     * access token 생성
+     *
+     */
+    public String generateAccessToken(final String email) {
+        final Claims claims = createPrivateClaims(email, TokenType.ACCESS_TOKEN);
+        return generateToken(claims, jwtProperties.getAccessTokenExpirationTime());
+    }
+
+    /**
+     * refershToken 생성
+     * refreshToken 만료 기간이 길기 때문에 redis에서 관리할 필요성이 떨어져 DB에 저장함
+     */
+    public String generateRefreshToken(final String email) {
+        final Claims claims = createPrivateClaims(email, TokenType.REFRESH_TOKEN);
+        final String refreshToken = generateToken(claims, jwtProperties.getRefreshTokenExpirationTime());
+        tokenSaveService.saveToken(refreshToken, email, TokenType.REFRESH_TOKEN);
+        return refreshToken;
+    }
+
+    /**
+     * refresh token을 이용하여 access token 재발급
+     *
+     */
+    public String reIssueAccessToken(final String refreshToken) {
+        validateToken(refreshToken);
+        final String email = extractEmailFromRefreshToken(refreshToken);
+        return generateAccessToken(email);
+    }
+
+    /**
+     * accessToken에서 email 추출
+     */
+    public String extractEmailFromAccessToken(final String accessToken){
+        return initializeJwtParser()
+                .parseClaimsJws(accessToken)
+                .getBody()
+                .get(JWTConsts.EMAIL)
+                .toString();
+    }
+
+
+    /**
+     * DB에서 refresh token(value)를 이용한 email(key) 추출
+     *
+     */
+    private String extractEmailFromRefreshToken(String refreshToken) {
+        final String email = tokenQueryService.findEmailByToken(refreshToken, TokenType.REFRESH_TOKEN);
+        return email;
+    }
+
+    /**
+     * 기본 jwt claims 스팩에서 개발자가 더 추가한 claim을 private claim이라고 함
+     * <br>private claims : email, tokenType + issuer
+     *
+     * @param email     토큰에 담길 email
+     * @param tokenType 토큰 타입(ACCESS_TOKEN, REFRESH_TOKEN)
+     */
+    private Claims createPrivateClaims(final String email, final TokenType tokenType) {
+        final Map<String, Object> claims = new HashMap<>();
+        claims.put(JWTConsts.EMAIL, email);
+        claims.put(JWTConsts.TOKEN_TYPE, tokenType.name());
+        return Jwts.claims(claims)
+                .setIssuer(JWTConsts.TOKEN_ISSUER);
+    }
+
+    /**
+     * 토큰 생성 메소드
+     *
+     */
+    private String generateToken(final Claims claims, final Long expirationTime) {
+        final Date now = new Date();
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + expirationTime))
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    /**
+     * @return 서명에 사용할 Key 반환
+     */
+    private Key getSigningKey() {
+        return Keys.hmacShaKeyFor(Decoders.BASE64.decode(jwtProperties.getSecret()));
+    }
+
+    public void validateToken(final String token) {
+        final JwtParser jwtParser = initializeJwtParser();
+        try {
+            jwtParser.parse(token);
+        } catch (MalformedJwtException | SignatureException | IllegalArgumentException e) {
+            throw new InvalidTokenException(Error.INVALID_TOKEN);
+        } catch (ExpiredJwtException e) {
+            throw new ExpiredTokenException(Error.EXPIRED_TOKEN);
+        }
+    }
+
+    /**
+     * iss, key 설정
+     */
+    private JwtParser initializeJwtParser() {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .requireIssuer(JWTConsts.TOKEN_ISSUER)
+                .build();
+    }
+
+}

--- a/core-module/src/main/java/com/koa/coremodule/auth/domain/jwt/exception/ExpiredTokenException.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/domain/jwt/exception/ExpiredTokenException.java
@@ -1,0 +1,8 @@
+package com.koa.coremodule.auth.domain.jwt.exception;
+import com.koa.commonmodule.exception.Error;
+
+public class ExpiredTokenException extends TokenException {
+    public ExpiredTokenException(Error error) {
+        super(error);
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/auth/domain/jwt/exception/InvalidTokenException.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/domain/jwt/exception/InvalidTokenException.java
@@ -1,0 +1,8 @@
+package com.koa.coremodule.auth.domain.jwt.exception;
+import com.koa.commonmodule.exception.Error;
+
+public class InvalidTokenException extends TokenException{
+    public InvalidTokenException(Error error) {
+        super(error);
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/auth/domain/jwt/exception/TokenException.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/domain/jwt/exception/TokenException.java
@@ -1,0 +1,11 @@
+package com.koa.coremodule.auth.domain.jwt.exception;
+
+
+import com.koa.commonmodule.exception.BusinessException;
+import com.koa.commonmodule.exception.Error;
+
+public class TokenException extends BusinessException {
+    public TokenException(Error error) {
+        super(error);
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/auth/domain/repository/TokenRepository.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/domain/repository/TokenRepository.java
@@ -1,0 +1,11 @@
+package com.koa.coremodule.auth.domain.repository;
+
+import com.koa.coremodule.auth.domain.entity.Token;
+import com.koa.coremodule.auth.domain.entity.TokenType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TokenRepository extends JpaRepository<Token, Long> {
+    Optional<Token> findByTokenValueAndTokenType(String email, TokenType tokenType);;
+}

--- a/core-module/src/main/java/com/koa/coremodule/auth/domain/service/TokenQueryService.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/domain/service/TokenQueryService.java
@@ -1,0 +1,22 @@
+package com.koa.coremodule.auth.domain.service;
+
+import com.koa.commonmodule.annotation.DomainService;
+import com.koa.commonmodule.exception.Error;
+import com.koa.coremodule.auth.domain.entity.Token;
+import com.koa.coremodule.auth.domain.entity.TokenType;
+import com.koa.coremodule.auth.domain.exception.NotExistTokenException;
+import com.koa.coremodule.auth.domain.repository.TokenRepository;
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class TokenQueryService {
+
+    private final TokenRepository tokenRepository;
+
+    public String findEmailByToken(final String value, final TokenType tokenType) {
+        Token token = tokenRepository.findByTokenValueAndTokenType(value, tokenType)
+                .orElseThrow(() -> new NotExistTokenException(Error.NOT_EXIST_TOKEN));
+        return token.getEmail();
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/auth/domain/service/TokenSaveService.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/domain/service/TokenSaveService.java
@@ -1,0 +1,16 @@
+package com.koa.coremodule.auth.domain.service;
+
+import com.koa.commonmodule.annotation.DomainService;
+import com.koa.coremodule.auth.domain.entity.Token;
+import com.koa.coremodule.auth.domain.entity.TokenType;
+import com.koa.coremodule.auth.domain.repository.TokenRepository;
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class TokenSaveService {
+    private final TokenRepository tokenRepository;
+    public void saveToken( final String token, final String email, final TokenType tokenType){
+        tokenRepository.save(Token.createToken(tokenType, email, token));
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/member/domain/exception/UserException.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/domain/exception/UserException.java
@@ -1,0 +1,10 @@
+package com.koa.coremodule.member.domain.exception;
+
+import com.koa.commonmodule.exception.BusinessException;
+import com.koa.commonmodule.exception.Error;
+
+public class UserException extends BusinessException {
+    public UserException(Error error) {
+        super(error);
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/member/domain/exception/UserNotFoundException.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/domain/exception/UserNotFoundException.java
@@ -1,0 +1,6 @@
+package com.koa.coremodule.member.domain.exception;
+import com.koa.commonmodule.exception.Error;
+
+public class UserNotFoundException extends UserException{
+    public UserNotFoundException(Error error) { super(error); }
+}

--- a/core-module/src/main/java/com/koa/coremodule/member/domain/repository/MemberRepository.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/domain/repository/MemberRepository.java
@@ -1,0 +1,13 @@
+package com.koa.coremodule.member.domain.repository;
+
+import com.koa.coremodule.member.domain.entity.Authority;
+import com.koa.coremodule.member.domain.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    boolean existsByEmailAndAuthority(String email, Authority authority);
+
+    Optional<Member> findByEmail(String email);
+}

--- a/core-module/src/main/java/com/koa/coremodule/member/domain/service/MemberQueryService.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/domain/service/MemberQueryService.java
@@ -1,0 +1,23 @@
+package com.koa.coremodule.member.domain.service;
+
+import com.koa.commonmodule.annotation.DomainService;
+import com.koa.commonmodule.exception.Error;
+import com.koa.coremodule.member.domain.entity.Authority;
+import com.koa.coremodule.member.domain.entity.Member;
+import com.koa.coremodule.member.domain.exception.UserNotFoundException;
+import com.koa.coremodule.member.domain.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@DomainService
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberQueryService {
+    private final MemberRepository memberRepository;
+
+    public void checkAccountExist(String email, Authority authority) {
+        if(!memberRepository.existsByEmailAndAuthority(email,authority)) {
+            throw new UserNotFoundException(Error.USER_NOT_FOUND);
+        }
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/member/domain/service/MemberQueryService.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/domain/service/MemberQueryService.java
@@ -20,4 +20,9 @@ public class MemberQueryService {
             throw new UserNotFoundException(Error.MEMBER_NOT_FOUND);
         }
     }
+
+    public Member findByEmail(String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new UserNotFoundException(Error.MEMBER_NOT_FOUND));
+    }
 }

--- a/core-module/src/main/java/com/koa/coremodule/member/domain/service/MemberQueryService.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/domain/service/MemberQueryService.java
@@ -17,7 +17,7 @@ public class MemberQueryService {
 
     public void checkAccountExist(String email, Authority authority) {
         if(!memberRepository.existsByEmailAndAuthority(email,authority)) {
-            throw new UserNotFoundException(Error.USER_NOT_FOUND);
+            throw new UserNotFoundException(Error.MEMBER_NOT_FOUND);
         }
     }
 }

--- a/core-module/src/main/java/com/koa/coremodule/member/domain/utils/MemberUtils.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/domain/utils/MemberUtils.java
@@ -1,0 +1,24 @@
+package com.koa.coremodule.member.domain.utils;
+
+import com.koa.commonmodule.utils.SecurityUtils;
+import com.koa.coremodule.member.domain.entity.Member;
+import com.koa.coremodule.member.domain.service.MemberQueryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MemberUtils {
+    private final MemberQueryService memberQueryService;
+
+    public Member getAccessMember(){
+        final String email = SecurityUtils.getAuthenticationPrincipal();
+        return memberQueryService.findByEmail(email);
+    }
+
+    public static String getEmailFromAccessUser(){
+        return SecurityUtils.getAuthenticationPrincipal();
+    }
+}


### PR DESCRIPTION
- Spring Security를 커스터마이징 하기 위해 UserDetailsServiceAutoConfiguration을 제외하였고, 컴포넌트 스캔을 위한 어노테이션을 추가했습니다.
- 디자인 패턴 중 하나인 커맨드 패턴을 사용해 운영진 로그인과 학회원 로그인을 하나의 API로 통합시켰습니다. @PathVariable를 통해 권한을 받으면, AuthInvoker를 통해 해당 권한을 가진 handler를 실행시키는 방식입니다. 추후에 권한이 더 생기거나(OB 같은), 유지 보수를 해야 하는 경우가 발생할 수 있기 때문에 해당 디자인 패턴을 사용했습니다. 
- 로그인 로직과 관련된 MemberQueryService를 추가했습니다. 
- JWT 토큰을 생성하고 관리하기 위한 역할을 하는 JWTProvider를 추가했습니다. 또한 JWT 관련 상수 클래스인 AuthConsts, 토큰 검증을 무시하게 할 경로를 관리하는 상수 클래스 IgnoredPathConsts 를 추가했습니다.  
- RefreshToken 만료 기간을 일주일로 설정했기 때문에 RefreshToken을 DB에서 관리하도록 설정했습니다. 만료 기간이 길어서 redis에서 관리하는 의미가 떨어지고, 해당 기수 학회원만 사용하기에 유저 수가 적은 명수로 고정되어 있고 , DB에서 토큰과 이메일만 저장해서 필요할 때 해당 값만 가져오므로 DB 부하가 일어나거나 하는 일은 적을 것으로 판단해서 DB에서 관리하도록 했습니다. 
- SecurityConfig 추가하였고, 다음과 같은 작업을 하는 커스텀 필터인 JWTAuthenticationFilter를 추가했고, 커스텀 인증 클래스인 JWTAuthenticationToken를 추가했습니다. 
    - HTTP 요청에서 JWT 토큰을 추출하고, 헤더에서 토큰 값을 가져옵니다.
    - 추출한 토큰을 사용하여 JWT 유효성을 검사합니다.
    - 유효한 JWT 토큰에서 사용자의 이메일 정보를 추출합니다.
    - 추출한 이메일 정보를 사용하여 사용자를 인증합니다.
    - 무시할 경로와 HTTP 메서드를 확인하여 해당 경로 및 메서드에 대한 요청을 무시합니다.
- JWTAuthenticationFilter에서 사용하는 토큰 추출, 토큰으로부터 email 추출, 토큰 검증 UseCase를 추가했습니다. 
- auth.application, auth.domain, member.domain 예외처리를 추가했습니다.  상위 Exception 클래스는 BusinessException을  extends 하고, 하위 Exception 클래스는 해당 클래스를 extends 합니다. 
- Member 객체를 가져오는 MemberUtil 클래스를 추가했습니다.