### PR TITLE
사용자 상세 정보 API 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ out/
 .vscode/
 
 api-module/src/main/resources/application-prod.yml
+api-module/src/main/resources/application-local.yml

--- a/api-module/src/main/java/com/koa/apimodule/auth/security/filter/JWTAuthenticationFilter.java
+++ b/api-module/src/main/java/com/koa/apimodule/auth/security/filter/JWTAuthenticationFilter.java
@@ -56,7 +56,7 @@ public class JWTAuthenticationFilter extends OncePerRequestFilter {
 
     private Boolean isMatchingPath(HttpServletRequest request, String ignoredPathURI){
         final AntPathMatcher antPathMatcher = new AntPathMatcher();
-        return antPathMatcher.matchStart(ignoredPathURI, request.getRequestURI());
+        return antPathMatcher.match(ignoredPathURI, request.getRequestURI());
     }
 
     private Boolean isMatchingMethod(HttpServletRequest request, String ignoredPathURI) {

--- a/api-module/src/main/java/com/koa/apimodule/command/api/MemberController.java
+++ b/api-module/src/main/java/com/koa/apimodule/command/api/MemberController.java
@@ -1,12 +1,21 @@
 package com.koa.apimodule.command.api;
 
-import com.koa.coremodule.member.application.dto.MemberInfo;
+import com.koa.coremodule.member.application.dto.request.MemberDetailCreateRequest;
+import com.koa.coremodule.member.application.dto.response.MemberDetailInfoResponse;
+import com.koa.coremodule.member.application.dto.response.MemberInfoResponse;
+import com.koa.coremodule.member.application.dto.response.RegisterResponse;
+import com.koa.coremodule.member.application.service.MemberDetailCreateUseCase;
 import com.koa.coremodule.member.application.service.MemberInfoGetUseCase;
+import com.koa.coremodule.member.application.service.MemberRegisterGetUseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RestController
@@ -15,9 +24,26 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
 
     private final MemberInfoGetUseCase memberInfoGetUseCase;
+    private final MemberDetailCreateUseCase memberInfoCreateUseCase;
+    private final MemberRegisterGetUseCase memberRegisterGetUseCase;
 
-    @GetMapping()
-    public MemberInfo getMemberInfo(){
+    @GetMapping
+    public MemberInfoResponse getMemberInfo(){
         return memberInfoGetUseCase.getMemberInfo();
+    }
+
+    @PostMapping
+    public void postMemberInfo(@RequestPart(value = "dto") MemberDetailCreateRequest memberInfoCreateRequest, @RequestPart(value = "file") MultipartFile multipartFile){
+        memberInfoCreateUseCase.createMemberInfo(memberInfoCreateRequest, multipartFile);
+    }
+
+    @PostMapping("/register")
+    public RegisterResponse authJoin(@RequestParam String email, @RequestParam String password) {
+        return memberRegisterGetUseCase.getMemberRegistered(email, password);
+    }
+
+    @GetMapping("/info")
+    public MemberDetailInfoResponse getMemberDetailInfo() {
+        return memberInfoGetUseCase.getMemberDetailInfo();
     }
 }

--- a/common-module/src/main/java/com/koa/commonmodule/exception/Error.java
+++ b/common-module/src/main/java/com/koa/commonmodule/exception/Error.java
@@ -16,8 +16,6 @@ public enum Error {
     DUPLICATE_REPORT("이미 등록된 신고내용입니다.", 400),
 
     //NOTICE
-    FILE_UPLOAD_FAIL("파일 업로드에 실패했습니다.", 500),
-    WRONG_FILE_FORMAT("잘못된 파일 확장자입니다.", 400),
 
     // MEMBER
     MEMBER_NOT_FOUND("사용자를 찾을 수 없습니다.", 2000),
@@ -27,7 +25,12 @@ public enum Error {
 
     //COMMENT
     COMMENT_NOT_FOUND("댓글을 찾을 수 없습니다.", 4000),
-    NOT_SAME_USER("작성자가 아닙니다.", 4001);
+    NOT_SAME_USER("작성자가 아닙니다.", 4001),
+
+    // IMAGE
+    FILE_UPLOAD_FAIL("파일 업로드에 실패했습니다.", 5000),
+    WRONG_FILE_FORMAT("잘못된 파일 확장자입니다.", 5001),
+    FILE_DELETE_FAIL("파일 삭제에 실패했습니다.", 5002);
 
     private final String message;
     private final int errorCode;

--- a/core-module/src/main/java/com/koa/coremodule/auth/application/common/consts/IgnoredPathConsts.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/application/common/consts/IgnoredPathConsts.java
@@ -14,7 +14,7 @@ public class IgnoredPathConsts {
     @Getter
     private static Map<String, Set<HttpMethod>> ignoredPath = Map.of(
             "/docs/**", Set.of(HttpMethod.GET),
-            "/oauth/**", Set.of(HttpMethod.GET),
+            "/v1/member/register", Set.of(HttpMethod.POST),
             "/h2-console/**", Set.of(HttpMethod.GET, HttpMethod.POST),
             "/v1/auth/login/**", Set.of(HttpMethod.GET, HttpMethod.POST),
             "/api-docs/**", Set.of(HttpMethod.GET, HttpMethod.POST),

--- a/core-module/src/main/java/com/koa/coremodule/image/exception/FileDeleteException.java
+++ b/core-module/src/main/java/com/koa/coremodule/image/exception/FileDeleteException.java
@@ -1,0 +1,8 @@
+package com.koa.coremodule.image.exception;
+import com.koa.commonmodule.exception.Error;
+
+public class FileDeleteException extends ImageException{
+    public FileDeleteException(Error error) {
+        super(error);
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/image/exception/FileExtensionException.java
+++ b/core-module/src/main/java/com/koa/coremodule/image/exception/FileExtensionException.java
@@ -1,0 +1,9 @@
+package com.koa.coremodule.image.exception;
+import com.koa.commonmodule.exception.Error;
+
+
+public class FileExtensionException extends ImageException{
+    public FileExtensionException(Error error) {
+        super(error);
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/image/exception/FileUploadException.java
+++ b/core-module/src/main/java/com/koa/coremodule/image/exception/FileUploadException.java
@@ -1,0 +1,10 @@
+package com.koa.coremodule.image.exception;
+
+import com.koa.commonmodule.exception.Error;
+
+public class FileUploadException extends ImageException {
+    public FileUploadException(Error error) {
+        super(error);
+    }
+}
+

--- a/core-module/src/main/java/com/koa/coremodule/image/exception/ImageException.java
+++ b/core-module/src/main/java/com/koa/coremodule/image/exception/ImageException.java
@@ -1,0 +1,10 @@
+package com.koa.coremodule.image.exception;
+
+import com.koa.commonmodule.exception.BusinessException;
+import com.koa.commonmodule.exception.Error;
+
+public class ImageException extends BusinessException {
+    public ImageException(Error error) {
+        super(error);
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/member/application/dto/request/InterestCreateRequest.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/application/dto/request/InterestCreateRequest.java
@@ -1,0 +1,11 @@
+package com.koa.coremodule.member.application.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class InterestCreateRequest {
+    private String category;
+    private String content;
+}

--- a/core-module/src/main/java/com/koa/coremodule/member/application/dto/request/LinkCreateRequest.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/application/dto/request/LinkCreateRequest.java
@@ -1,0 +1,11 @@
+package com.koa.coremodule.member.application.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LinkCreateRequest {
+    private String type;
+    private String link;
+}

--- a/core-module/src/main/java/com/koa/coremodule/member/application/dto/request/MemberDetailCreateRequest.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/application/dto/request/MemberDetailCreateRequest.java
@@ -1,0 +1,18 @@
+package com.koa.coremodule.member.application.dto.request;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberDetailCreateRequest {
+
+    private String major;
+    private String part;
+    private List<InterestCreateRequest> interests;
+    private String phoneNumber;
+    private String description;
+    private List<LinkCreateRequest> links;
+
+}

--- a/core-module/src/main/java/com/koa/coremodule/member/application/dto/response/InterestInfoResponse.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/application/dto/response/InterestInfoResponse.java
@@ -1,0 +1,14 @@
+package com.koa.coremodule.member.application.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+public class InterestInfoResponse {
+    private String category;
+    private String content;
+}

--- a/core-module/src/main/java/com/koa/coremodule/member/application/dto/response/LinkInfoResponse.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/application/dto/response/LinkInfoResponse.java
@@ -1,0 +1,14 @@
+package com.koa.coremodule.member.application.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+public class LinkInfoResponse {
+    private String type;
+    private String link;
+}

--- a/core-module/src/main/java/com/koa/coremodule/member/application/dto/response/MemberDetailInfoResponse.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/application/dto/response/MemberDetailInfoResponse.java
@@ -1,0 +1,19 @@
+package com.koa.coremodule.member.application.dto.response;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+public class MemberDetailInfoResponse {
+    private String major;
+    private String part;
+    private List<InterestInfoResponse> interests;
+    private String phoneNumber;
+    private String description;
+    private List<LinkInfoResponse> links;
+}

--- a/core-module/src/main/java/com/koa/coremodule/member/application/dto/response/MemberInfoResponse.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/application/dto/response/MemberInfoResponse.java
@@ -1,4 +1,4 @@
-package com.koa.coremodule.member.application.dto;
+package com.koa.coremodule.member.application.dto.response;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -8,7 +8,8 @@ import lombok.Getter;
 @Getter
 @Builder
 @AllArgsConstructor(access = AccessLevel.PUBLIC)
-public class MemberInfo {
+public class MemberInfoResponse {
     private String name;
     private String email;
+    private boolean isMemberDetailExist;
 }

--- a/core-module/src/main/java/com/koa/coremodule/member/application/dto/response/RegisterResponse.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/application/dto/response/RegisterResponse.java
@@ -1,0 +1,14 @@
+package com.koa.coremodule.member.application.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+public class RegisterResponse {
+    
+    boolean isRegistered;
+}

--- a/core-module/src/main/java/com/koa/coremodule/member/application/mapper/MemberMapper.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/application/mapper/MemberMapper.java
@@ -1,17 +1,83 @@
 package com.koa.coremodule.member.application.mapper;
 
-import com.koa.coremodule.member.application.dto.MemberInfo;
+import com.koa.coremodule.member.application.dto.request.InterestCreateRequest;
+import com.koa.coremodule.member.application.dto.request.LinkCreateRequest;
+import com.koa.coremodule.member.application.dto.request.MemberDetailCreateRequest;
+import com.koa.coremodule.member.application.dto.response.InterestInfoResponse;
+import com.koa.coremodule.member.application.dto.response.LinkInfoResponse;
+import com.koa.coremodule.member.application.dto.response.MemberDetailInfoResponse;
+import com.koa.coremodule.member.application.dto.response.MemberInfoResponse;
+import com.koa.coremodule.member.domain.entity.Category;
+import com.koa.coremodule.member.domain.entity.Interest;
+import com.koa.coremodule.member.domain.entity.Link;
 import com.koa.coremodule.member.domain.entity.Member;
+import com.koa.coremodule.member.domain.entity.MemberDetail;
+import com.koa.coremodule.member.domain.entity.Part;
+import com.koa.coremodule.member.domain.entity.Type;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberMapper {
 
-    public static MemberInfo mapToMemberInfo(Member member){
-        return MemberInfo.builder()
+    public static MemberInfoResponse mapToMemberInfoResponse(Member member, boolean isMemberDetailExist){
+        return MemberInfoResponse.builder()
                 .name(member.getName())
                 .email(member.getEmail())
+                .isMemberDetailExist(isMemberDetailExist)
+                .build();
+    }
+
+    public static MemberDetail mapToMemberInfo(Member member, MemberDetailCreateRequest memberInfoCreateRequest, String imageUrl){
+        return MemberDetail.builder()
+                .major(memberInfoCreateRequest.getMajor())
+                .part(Part.valueOf(memberInfoCreateRequest.getPart()))
+                .phoneNumber(memberInfoCreateRequest.getPhoneNumber())
+                .description(memberInfoCreateRequest.getDescription())
+                .profileImage(imageUrl)
+                .member(member)
+                .build();
+    }
+
+    public static Interest mapToInterest(InterestCreateRequest interestCreateRequest, MemberDetail memberDetail){
+        return Interest.builder()
+                .category(Category.valueOf(interestCreateRequest.getCategory()))
+                .content(interestCreateRequest.getContent())
+                .memberDetail(memberDetail)
+                .build();
+    }
+
+    public static Link mapToLink(LinkCreateRequest linkCreateRequest, MemberDetail memberDetail){
+        return Link.builder()
+                .type(Type.valueOf(linkCreateRequest.getType()))
+                .link(linkCreateRequest.getLink())
+                .memberDetail(memberDetail)
+                .build();
+    }
+
+    public static MemberDetailInfoResponse mapToMemberDetailInfoResponse(MemberDetail memberDetail, List<InterestInfoResponse> interests, List<LinkInfoResponse> links){
+        return MemberDetailInfoResponse.builder()
+                .major(memberDetail.getMajor())
+                .part(memberDetail.getPart().toString())
+                .interests(interests)
+                .phoneNumber(memberDetail.getPhoneNumber())
+                .description(memberDetail.getDescription())
+                .links(links)
+                .build();
+    }
+
+    public static InterestInfoResponse mapToInterestInfoResponse(Interest interest){
+        return InterestInfoResponse.builder()
+                .category(interest.getCategory().toString())
+                .content(interest.getContent())
+                .build();
+    }
+
+    public static LinkInfoResponse mapToLinkInfoResponse(Link link){
+        return LinkInfoResponse.builder()
+                .type(link.getType().toString())
+                .link(link.getLink())
                 .build();
     }
 }

--- a/core-module/src/main/java/com/koa/coremodule/member/application/service/MemberDetailCreateUseCase.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/application/service/MemberDetailCreateUseCase.java
@@ -1,0 +1,48 @@
+package com.koa.coremodule.member.application.service;
+
+import com.koa.commonmodule.annotation.ApplicationService;
+import com.koa.coremodule.image.service.AwsS3Service;
+import com.koa.coremodule.member.application.dto.request.MemberDetailCreateRequest;
+import com.koa.coremodule.member.application.mapper.MemberMapper;
+import com.koa.coremodule.member.domain.entity.Interest;
+import com.koa.coremodule.member.domain.entity.Link;
+import com.koa.coremodule.member.domain.entity.Member;
+import com.koa.coremodule.member.domain.entity.MemberDetail;
+import com.koa.coremodule.member.domain.service.InterestSaveService;
+import com.koa.coremodule.member.domain.service.LinkSaveService;
+import com.koa.coremodule.member.domain.service.MemberDetailSaveService;
+import com.koa.coremodule.member.domain.utils.MemberUtils;
+import jakarta.transaction.Transactional;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+@ApplicationService
+@RequiredArgsConstructor
+@Transactional
+public class MemberDetailCreateUseCase {
+
+    private final MemberUtils memberUtils;
+    private final MemberDetailSaveService memberDetailSaveService;
+    private final InterestSaveService interestSaveService;
+    private final LinkSaveService linkSaveService;
+    private final AwsS3Service awsS3Service;
+
+    public void createMemberInfo(MemberDetailCreateRequest memberInfoCreateRequest, MultipartFile multipartFile) {
+        String imageUrl = Optional.ofNullable(multipartFile)
+                .map(awsS3Service::uploadFile)
+                .orElse(null);
+
+        Member member = memberUtils.getAccessMember();
+        MemberDetail memberDetail = MemberMapper.mapToMemberInfo(member, memberInfoCreateRequest, imageUrl);
+        memberDetailSaveService.saveMemberInfoEntity(memberDetail);
+        memberInfoCreateRequest.getInterests().forEach(interestRequest -> {
+            Interest interest = MemberMapper.mapToInterest(interestRequest, memberDetail);
+            interestSaveService.saveInterestEntity(interest);
+        });
+        memberInfoCreateRequest.getLinks().forEach(linkRequest -> {
+            Link link = MemberMapper.mapToLink(linkRequest, memberDetail);
+            linkSaveService.saveLinkEntity(link);
+        });
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/member/application/service/MemberInfoGetUseCase.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/application/service/MemberInfoGetUseCase.java
@@ -1,10 +1,20 @@
 package com.koa.coremodule.member.application.service;
 
 import com.koa.commonmodule.annotation.ApplicationService;
-import com.koa.coremodule.member.application.dto.MemberInfo;
+import com.koa.coremodule.member.application.dto.response.InterestInfoResponse;
+import com.koa.coremodule.member.application.dto.response.LinkInfoResponse;
+import com.koa.coremodule.member.application.dto.response.MemberDetailInfoResponse;
+import com.koa.coremodule.member.application.dto.response.MemberInfoResponse;
 import com.koa.coremodule.member.application.mapper.MemberMapper;
+import com.koa.coremodule.member.domain.entity.Interest;
+import com.koa.coremodule.member.domain.entity.Link;
 import com.koa.coremodule.member.domain.entity.Member;
+import com.koa.coremodule.member.domain.entity.MemberDetail;
+import com.koa.coremodule.member.domain.service.InterestQueryService;
+import com.koa.coremodule.member.domain.service.LinkQueryService;
+import com.koa.coremodule.member.domain.service.MemberDetailQueryService;
 import com.koa.coremodule.member.domain.utils.MemberUtils;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,9 +24,27 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberInfoGetUseCase {
 
     private final MemberUtils memberUtils;
+    private final MemberDetailQueryService memberDetailQueryService;
+    private final InterestQueryService interestQueryService;
+    private final LinkQueryService linkQueryService;
 
-    public MemberInfo getMemberInfo(){
+    public MemberInfoResponse getMemberInfo(){
         final Member member = memberUtils.getAccessMember();
-        return MemberMapper.mapToMemberInfo(member);
+        boolean isMemberDetailExist = memberDetailQueryService.isMemberDetailExist(member.getId());
+        return MemberMapper.mapToMemberInfoResponse(member, isMemberDetailExist);
+    }
+
+    public MemberDetailInfoResponse getMemberDetailInfo(){
+        final Member member = memberUtils.getAccessMember();
+        final MemberDetail memberDetail = memberDetailQueryService.findMemberDatailByMemberId(member.getId());
+        final List<Interest> interests = interestQueryService.findInterestsByMemberDetailId(memberDetail.getId());
+        final List<InterestInfoResponse> interestInfoResponses = interests.stream()
+                .map(MemberMapper::mapToInterestInfoResponse)
+                .toList();
+        final List<Link> links =  linkQueryService.findLinksByMemberDetailId(memberDetail.getId());
+        final List<LinkInfoResponse> linkInfoResponses = links.stream()
+                .map(MemberMapper::mapToLinkInfoResponse)
+                .toList();
+        return MemberMapper.mapToMemberDetailInfoResponse(memberDetail, interestInfoResponses, linkInfoResponses);
     }
 }

--- a/core-module/src/main/java/com/koa/coremodule/member/application/service/MemberRegisterGetUseCase.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/application/service/MemberRegisterGetUseCase.java
@@ -1,0 +1,20 @@
+package com.koa.coremodule.member.application.service;
+
+import com.koa.commonmodule.annotation.ApplicationService;
+import com.koa.coremodule.member.application.dto.response.RegisterResponse;
+import com.koa.coremodule.member.domain.service.MemberQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@ApplicationService
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberRegisterGetUseCase {
+
+    private final MemberQueryService memberQueryService;
+
+    public RegisterResponse getMemberRegistered(String email, String password) {
+        boolean isRegistered = memberQueryService.checkRegister(email, password);
+        return new RegisterResponse(isRegistered);
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/member/domain/entity/Category.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/domain/entity/Category.java
@@ -1,0 +1,5 @@
+package com.koa.coremodule.member.domain.entity;
+
+public enum Category {
+    PLANNING, DESIGN, DEVELOPMENT, EXTRA
+}

--- a/core-module/src/main/java/com/koa/coremodule/member/domain/entity/Interest.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/domain/entity/Interest.java
@@ -1,0 +1,35 @@
+package com.koa.coremodule.member.domain.entity;
+
+import com.koa.commonmodule.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+public class Interest extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "interest_id")
+    private Long id;
+
+    private Category category;
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_info_id")
+    private MemberDetail memberDetail;
+}

--- a/core-module/src/main/java/com/koa/coremodule/member/domain/entity/Link.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/domain/entity/Link.java
@@ -1,0 +1,35 @@
+package com.koa.coremodule.member.domain.entity;
+
+import com.koa.commonmodule.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+public class Link extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "link_id")
+    private Long id;
+
+    private Type type;
+    private String link;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_info_id")
+    private MemberDetail memberDetail;
+}

--- a/core-module/src/main/java/com/koa/coremodule/member/domain/entity/MemberDetail.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/domain/entity/MemberDetail.java
@@ -1,0 +1,39 @@
+package com.koa.coremodule.member.domain.entity;
+
+import com.koa.commonmodule.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+public class MemberDetail extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_info_id")
+    private Long id;
+
+    private String major;
+    private Part part;
+    private String phoneNumber;
+    private String description;
+    private String profileImage;
+
+    
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/core-module/src/main/java/com/koa/coremodule/member/domain/entity/Part.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/domain/entity/Part.java
@@ -1,0 +1,5 @@
+package com.koa.coremodule.member.domain.entity;
+
+public enum Part {
+    PLANNING, DESIGN, DEVELOPMENT
+}

--- a/core-module/src/main/java/com/koa/coremodule/member/domain/entity/Type.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/domain/entity/Type.java
@@ -1,0 +1,5 @@
+package com.koa.coremodule.member.domain.entity;
+
+public enum Type {
+    LINK, BRUNCH, TISTORY, NOTION, BEHANCE, LINKEDIN, GITHUB
+}

--- a/core-module/src/main/java/com/koa/coremodule/member/domain/repository/InterestRepository.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/domain/repository/InterestRepository.java
@@ -1,0 +1,11 @@
+package com.koa.coremodule.member.domain.repository;
+
+import com.koa.coremodule.member.domain.entity.Interest;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface InterestRepository extends JpaRepository<Interest, Long> {
+    @Query("select i from Interest i where i.memberDetail.id = :memberDetailId")
+    List<Interest> findAllByMemberDetailId(Long memberDetailId);
+}

--- a/core-module/src/main/java/com/koa/coremodule/member/domain/repository/LinkRepository.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/domain/repository/LinkRepository.java
@@ -1,0 +1,11 @@
+package com.koa.coremodule.member.domain.repository;
+
+import com.koa.coremodule.member.domain.entity.Link;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface LinkRepository extends JpaRepository<Link, Long> {
+    @Query("select l from Link l where l.memberDetail.id = :memberDetailId")
+    List<Link> findAllByMemberDetailId(Long memberDetailId);
+}

--- a/core-module/src/main/java/com/koa/coremodule/member/domain/repository/MemberDetailRepository.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/domain/repository/MemberDetailRepository.java
@@ -1,0 +1,13 @@
+package com.koa.coremodule.member.domain.repository;
+
+import com.koa.coremodule.member.domain.entity.MemberDetail;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface MemberDetailRepository extends JpaRepository<MemberDetail, Long> {
+    @Query("select m from MemberDetail m where m.member.id = :memberId")
+    Optional<MemberDetail> findByMemberId(Long memberId);
+
+    boolean existsByMemberId(Long memberId);
+}

--- a/core-module/src/main/java/com/koa/coremodule/member/domain/repository/MemberRepository.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/domain/repository/MemberRepository.java
@@ -2,12 +2,12 @@ package com.koa.coremodule.member.domain.repository;
 
 import com.koa.coremodule.member.domain.entity.Authority;
 import com.koa.coremodule.member.domain.entity.Member;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmailAndAuthority(String email, Authority authority);
+    boolean existsByEmailAndPassword(String email, String password);
 
     Optional<Member> findByEmail(String email);
 }

--- a/core-module/src/main/java/com/koa/coremodule/member/domain/service/InterestQueryService.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/domain/service/InterestQueryService.java
@@ -1,0 +1,19 @@
+package com.koa.coremodule.member.domain.service;
+
+import com.koa.commonmodule.annotation.DomainService;
+import com.koa.coremodule.member.domain.entity.Interest;
+import com.koa.coremodule.member.domain.repository.InterestRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@DomainService
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class InterestQueryService {
+    private final InterestRepository interstRepository;
+
+    public List<Interest> findInterestsByMemberDetailId(Long memberDetailId) {
+        return interstRepository.findAllByMemberDetailId(memberDetailId);
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/member/domain/service/InterestSaveService.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/domain/service/InterestSaveService.java
@@ -1,0 +1,18 @@
+package com.koa.coremodule.member.domain.service;
+
+import com.koa.commonmodule.annotation.DomainService;
+import com.koa.coremodule.member.domain.entity.Interest;
+import com.koa.coremodule.member.domain.repository.InterestRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@DomainService
+@Transactional
+@RequiredArgsConstructor
+public class InterestSaveService {
+    private final InterestRepository interestRepository;
+
+    public void saveInterestEntity(Interest interest){
+        interestRepository.save(interest);
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/member/domain/service/LinkQueryService.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/domain/service/LinkQueryService.java
@@ -1,0 +1,19 @@
+package com.koa.coremodule.member.domain.service;
+
+import com.koa.commonmodule.annotation.DomainService;
+import com.koa.coremodule.member.domain.entity.Link;
+import com.koa.coremodule.member.domain.repository.LinkRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@DomainService
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class LinkQueryService {
+    private final LinkRepository linkRepository;
+
+    public List<Link> findLinksByMemberDetailId(Long memberDetailId) {
+        return linkRepository.findAllByMemberDetailId(memberDetailId);
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/member/domain/service/LinkSaveService.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/domain/service/LinkSaveService.java
@@ -1,0 +1,18 @@
+package com.koa.coremodule.member.domain.service;
+
+import com.koa.commonmodule.annotation.DomainService;
+import com.koa.coremodule.member.domain.entity.Link;
+import com.koa.coremodule.member.domain.repository.LinkRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@DomainService
+@Transactional
+@RequiredArgsConstructor
+public class LinkSaveService {
+    private final LinkRepository linkRepository;
+
+    public void saveLinkEntity(Link link){
+        linkRepository.save(link);
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/member/domain/service/MemberDetailQueryService.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/domain/service/MemberDetailQueryService.java
@@ -1,0 +1,25 @@
+package com.koa.coremodule.member.domain.service;
+
+import com.koa.commonmodule.annotation.DomainService;
+import com.koa.commonmodule.exception.Error;
+import com.koa.coremodule.member.domain.entity.MemberDetail;
+import com.koa.coremodule.member.domain.exception.UserNotFoundException;
+import com.koa.coremodule.member.domain.repository.MemberDetailRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@DomainService
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberDetailQueryService {
+    private final MemberDetailRepository memberDetailRepository;
+
+    public MemberDetail findMemberDatailByMemberId(Long memberId) {
+        return memberDetailRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new UserNotFoundException(Error.MEMBER_NOT_FOUND));
+    }
+
+    public boolean isMemberDetailExist(Long memberId){
+        return memberDetailRepository.existsByMemberId(memberId);
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/member/domain/service/MemberDetailSaveService.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/domain/service/MemberDetailSaveService.java
@@ -1,0 +1,18 @@
+package com.koa.coremodule.member.domain.service;
+
+import com.koa.commonmodule.annotation.DomainService;
+import com.koa.coremodule.member.domain.entity.MemberDetail;
+import com.koa.coremodule.member.domain.repository.MemberDetailRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@DomainService
+@Transactional
+@RequiredArgsConstructor
+public class MemberDetailSaveService {
+    private final MemberDetailRepository memberInfoRepository;
+
+    public void saveMemberInfoEntity(MemberDetail memberInfo){
+        memberInfoRepository.save(memberInfo);
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/member/domain/service/MemberQueryService.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/domain/service/MemberQueryService.java
@@ -21,6 +21,10 @@ public class MemberQueryService {
         }
     }
 
+    public boolean checkRegister(String email, String password) {
+        return memberRepository.existsByEmailAndPassword(email, password);
+    }
+
     public Member findByEmail(String email) {
         return memberRepository.findByEmail(email)
                 .orElseThrow(() -> new UserNotFoundException(Error.MEMBER_NOT_FOUND));

--- a/core-module/src/main/java/com/koa/coremodule/notice/application/service/NoticeSaveUseCase.java
+++ b/core-module/src/main/java/com/koa/coremodule/notice/application/service/NoticeSaveUseCase.java
@@ -1,5 +1,6 @@
 package com.koa.coremodule.notice.application.service;
 
+import com.koa.coremodule.image.service.AwsS3Service;
 import com.koa.coremodule.notice.application.dto.NoticeDetailResponse;
 import com.koa.coremodule.notice.application.dto.NoticeRequest;
 import com.koa.coremodule.notice.domain.service.NoticeQueryService;


### PR DESCRIPTION
- 사용자 상세 정보 저장, 조회 기능 추가했습니다.
- 사용자 상세 정보 저장에서도 이미지 업로드 기능이 있어, Notice 패키지에 있던 AwsS3Service를 image라는 패키지를 만들어 거기서 관리하도록 수정했습니다.
- 사용자 상세 정보 저장을 위한 Entity들을 추가했습니다.
- 사용자 회원가입 (단순 db에 저장되어있는 id,pw 비교) 체크 기능 추가했습니다.
- 로그인 후 사용자 정보 반환(이름과 이메일) dto에 상세 정보 작성 유무 필드를 추가했습니다 