### PR TITLE
feat : 이메일 인증, 로그아웃 기능

### DIFF
--- a/api-module/src/main/java/com/koa/apimodule/command/api/AuthController.java
+++ b/api-module/src/main/java/com/koa/apimodule/command/api/AuthController.java
@@ -1,5 +1,6 @@
 package com.koa.apimodule.command.api;
 
+import com.koa.coremodule.auth.application.common.consts.AuthConsts;
 import com.koa.coremodule.auth.application.dto.AuthResponse;
 import com.koa.coremodule.auth.application.service.AuthUseCase;
 import com.koa.coremodule.member.domain.entity.Authority;
@@ -22,7 +23,7 @@ public class AuthController {
     }
 
     @GetMapping("/reissue")
-    public AuthResponse authReissue(){
-        return authUseCase.reissue();
+    public AuthResponse authReissue(@RequestHeader(AuthConsts.REFRESH_TOKEN_HEADER) String refreshToken){
+        return authUseCase.reissue(refreshToken);
     }
 }

--- a/api-module/src/main/java/com/koa/apimodule/command/api/AuthController.java
+++ b/api-module/src/main/java/com/koa/apimodule/command/api/AuthController.java
@@ -3,6 +3,7 @@ package com.koa.apimodule.command.api;
 import com.koa.coremodule.auth.application.common.consts.AuthConsts;
 import com.koa.coremodule.auth.application.dto.AuthResponse;
 import com.koa.coremodule.auth.application.service.AuthUseCase;
+import com.koa.coremodule.auth.application.service.LogoutUseCase;
 import com.koa.coremodule.member.domain.entity.Authority;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +17,7 @@ public class AuthController {
 
 
     private final AuthUseCase authUseCase;
+    private final LogoutUseCase logoutUseCase;
 
     @GetMapping("/login/{authority}")
     public AuthResponse authLogin(@PathVariable Authority authority, @RequestParam String email, @RequestParam String password){
@@ -25,5 +27,10 @@ public class AuthController {
     @GetMapping("/reissue")
     public AuthResponse authReissue(@RequestHeader(AuthConsts.REFRESH_TOKEN_HEADER) String refreshToken){
         return authUseCase.reissue(refreshToken);
+    }
+
+    @DeleteMapping("/logout")
+    public void logout(@RequestHeader(AuthConsts.REFRESH_TOKEN_HEADER) String refreshToken){
+        logoutUseCase.logoutAccessUser(refreshToken);
     }
 }

--- a/api-module/src/main/java/com/koa/apimodule/command/api/MemberController.java
+++ b/api-module/src/main/java/com/koa/apimodule/command/api/MemberController.java
@@ -4,6 +4,7 @@ import com.koa.coremodule.member.application.dto.request.MemberDetailCreateReque
 import com.koa.coremodule.member.application.dto.response.MemberDetailInfoResponse;
 import com.koa.coremodule.member.application.dto.response.MemberInfoResponse;
 import com.koa.coremodule.member.application.dto.response.RegisterResponse;
+import com.koa.coremodule.member.application.service.EmailVerificationUseCase;
 import com.koa.coremodule.member.application.service.MemberDetailCreateUseCase;
 import com.koa.coremodule.member.application.service.MemberInfoGetUseCase;
 import com.koa.coremodule.member.application.service.MemberRegisterGetUseCase;
@@ -26,6 +27,7 @@ public class MemberController {
     private final MemberInfoGetUseCase memberInfoGetUseCase;
     private final MemberDetailCreateUseCase memberInfoCreateUseCase;
     private final MemberRegisterGetUseCase memberRegisterGetUseCase;
+    private final EmailVerificationUseCase emailVerificationUseCase;
 
     @GetMapping
     public MemberInfoResponse getMemberInfo(){
@@ -45,5 +47,15 @@ public class MemberController {
     @GetMapping("/info")
     public MemberDetailInfoResponse getMemberDetailInfo() {
         return memberInfoGetUseCase.getMemberDetailInfo();
+    }
+
+    @PostMapping("/verify")
+    public void postVerifyEmail(@RequestParam String email) {
+        emailVerificationUseCase.sendVerificationEmail(email);
+    }
+
+    @PostMapping("/verify/code")
+    public void verifyCode(@RequestParam String email, @RequestParam String code) {
+        emailVerificationUseCase.verifyCode(email, code);
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ subprojects {
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
         implementation 'org.springframework.boot:spring-boot-starter-web'
+        implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     }
 
     test {

--- a/common-module/src/main/java/com/koa/commonmodule/exception/Error.java
+++ b/common-module/src/main/java/com/koa/commonmodule/exception/Error.java
@@ -30,7 +30,11 @@ public enum Error {
     // IMAGE
     FILE_UPLOAD_FAIL("파일 업로드에 실패했습니다.", 5000),
     WRONG_FILE_FORMAT("잘못된 파일 확장자입니다.", 5001),
-    FILE_DELETE_FAIL("파일 삭제에 실패했습니다.", 5002);
+    FILE_DELETE_FAIL("파일 삭제에 실패했습니다.", 5002),
+
+    //Email
+    CREATE_CODE_FAIL("인증코드 생성에 실패했습니다.", 6000),
+    WRONG_CODE("잘못된 인증코드입니다.", 6001);
 
     private final String message;
     private final int errorCode;

--- a/common-module/src/main/java/com/koa/commonmodule/utils/RedisUtils.java
+++ b/common-module/src/main/java/com/koa/commonmodule/utils/RedisUtils.java
@@ -1,0 +1,37 @@
+package com.koa.commonmodule.utils;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisUtils {
+
+    private final StringRedisTemplate redisTemplate;
+
+    // key를 통해 value 리턴
+    public String getData(String key) {
+    ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+    return valueOperations.get(key);
+    }
+
+    public void setData(String key, String value) {
+    ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+    valueOperations.set(key, value);
+    }
+
+    // 유효 시간 동안 (key, value) 저장
+    public void setDataExpire(String key, String value, long duration) {
+    ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+    Duration expireDuration = Duration.ofMillis(duration);
+    valueOperations.set(key, value, expireDuration);
+    }
+
+    // 삭제
+    public void deleteData(String key) {
+    redisTemplate.delete(key);
+    }
+}

--- a/core-module/build.gradle
+++ b/core-module/build.gradle
@@ -2,7 +2,6 @@ dependencies {
     implementation project(':common-module')
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     // mapstruct
@@ -15,6 +14,8 @@ dependencies {
 
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
+
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 bootJar {

--- a/core-module/src/main/java/com/koa/coremodule/auth/application/common/consts/IgnoredPathConsts.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/application/common/consts/IgnoredPathConsts.java
@@ -1,5 +1,6 @@
 package com.koa.coremodule.auth.application.common.consts;
 
+import java.util.LinkedHashMap;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,17 +13,24 @@ import java.util.Set;
 public class IgnoredPathConsts {
 
     @Getter
-    private static Map<String, Set<HttpMethod>> ignoredPath = Map.of(
-            "/v1/auth/reissue", Set.of(HttpMethod.GET),
-            "/v1/member/register", Set.of(HttpMethod.POST),
-            "/h2-console/**", Set.of(HttpMethod.GET, HttpMethod.POST),
-            "/v1/auth/login/**", Set.of(HttpMethod.GET, HttpMethod.POST),
-            "/api-docs/**", Set.of(HttpMethod.GET, HttpMethod.POST),
-            "/error", Set.of(HttpMethod.GET, HttpMethod.POST),
-            "/favicon.ico", Set.of(HttpMethod.GET, HttpMethod.POST),
-            "/swagger-ui/**", Set.of(HttpMethod.GET, HttpMethod.POST),
-            "/swagger-resources/**", Set.of(HttpMethod.GET, HttpMethod.POST),
-            "/v3/api-docs/**", Set.of(HttpMethod.GET, HttpMethod.POST)
-    );
+    private static Map<String, Set<HttpMethod>> ignoredPath = createIgnoredPathMap();
 
+    private static Map<String, Set<HttpMethod>> createIgnoredPathMap() {
+        Map<String, Set<HttpMethod>> map = new LinkedHashMap<>();
+
+        map.put("/v1/auth/reissue", Set.of(HttpMethod.GET));
+        map.put("/v1/member/register", Set.of(HttpMethod.POST));
+        map.put("/h2-console/**", Set.of(HttpMethod.GET, HttpMethod.POST));
+        map.put("/v1/auth/login/**", Set.of(HttpMethod.GET, HttpMethod.POST));
+        map.put("/v1/member/verify", Set.of(HttpMethod.POST));
+        map.put("/v1/member/verify/code", Set.of(HttpMethod.POST));
+        map.put("/api-docs/**", Set.of(HttpMethod.GET, HttpMethod.POST));
+        map.put("/error", Set.of(HttpMethod.GET, HttpMethod.POST));
+        map.put("/favicon.ico", Set.of(HttpMethod.GET, HttpMethod.POST));
+        map.put("/swagger-ui/**", Set.of(HttpMethod.GET, HttpMethod.POST));
+        map.put("/swagger-resources/**", Set.of(HttpMethod.GET, HttpMethod.POST));
+        map.put("/v3/api-docs/**", Set.of(HttpMethod.GET, HttpMethod.POST));
+
+        return map;
+    }
 }

--- a/core-module/src/main/java/com/koa/coremodule/auth/application/common/consts/IgnoredPathConsts.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/application/common/consts/IgnoredPathConsts.java
@@ -13,7 +13,7 @@ public class IgnoredPathConsts {
 
     @Getter
     private static Map<String, Set<HttpMethod>> ignoredPath = Map.of(
-            "/docs/**", Set.of(HttpMethod.GET),
+            "/v1/auth/reissue", Set.of(HttpMethod.GET),
             "/v1/member/register", Set.of(HttpMethod.POST),
             "/h2-console/**", Set.of(HttpMethod.GET, HttpMethod.POST),
             "/v1/auth/login/**", Set.of(HttpMethod.GET, HttpMethod.POST),

--- a/core-module/src/main/java/com/koa/coremodule/auth/application/service/AuthUseCase.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/application/service/AuthUseCase.java
@@ -23,19 +23,13 @@ public class AuthUseCase {
         return oAuthInvoker.execute(new AuthRequest(authority, email, password));
     }
 
-    public AuthResponse reissue(){
-        final String refreshTokenHeader = getHeader(AuthConsts.REFRESH_TOKEN_HEADER);
-        final String token = TokenExtractUtils.extractToken(refreshTokenHeader);
-        String accessToken = jwtProvider.reIssueAccessToken(token);
-        String refreshToken = jwtProvider.reIssueRefreshToken(token);
+    public AuthResponse reissue(String refreshToken){
+        final String token = TokenExtractUtils.extractToken(refreshToken);
+        String reIssueAccessToken = jwtProvider.reIssueAccessToken(token);
+        String reIssueRefreshToken = jwtProvider.reIssueRefreshToken(token);
         return AuthResponse.builder()
-                .accessToken(accessToken)
-                .refreshToken(refreshToken)
+                .accessToken(reIssueAccessToken)
+                .refreshToken(reIssueRefreshToken)
                 .build();
-    }
-
-    private String getHeader(final String name){
-        return ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes())
-                .getRequest().getHeader(name);
     }
 }

--- a/core-module/src/main/java/com/koa/coremodule/auth/application/service/LogoutUseCase.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/application/service/LogoutUseCase.java
@@ -16,7 +16,7 @@ public class LogoutUseCase {
 
     public void logoutAccessUser(String refreshTokenHeader) {
         final String refreshToken = TokenExtractUtils.extractToken(refreshTokenHeader);
-        final Token refreshTokenEntity = tokenQueryService.findTokenByValue(refreshToken, TokenType.REFRESH_TOKEN);
+        final Token refreshTokenEntity = tokenQueryService.findTokenByTokenValue(refreshToken, TokenType.REFRESH_TOKEN);
         tokenDeleteService.deleteToken(refreshTokenEntity);
     }
 

--- a/core-module/src/main/java/com/koa/coremodule/auth/application/service/LogoutUseCase.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/application/service/LogoutUseCase.java
@@ -1,0 +1,23 @@
+package com.koa.coremodule.auth.application.service;
+
+import com.koa.commonmodule.annotation.ApplicationService;
+import com.koa.coremodule.auth.application.utils.TokenExtractUtils;
+import com.koa.coremodule.auth.domain.entity.Token;
+import com.koa.coremodule.auth.domain.entity.TokenType;
+import com.koa.coremodule.auth.domain.service.TokenDeleteService;
+import com.koa.coremodule.auth.domain.service.TokenQueryService;
+import lombok.RequiredArgsConstructor;
+
+@ApplicationService
+@RequiredArgsConstructor
+public class LogoutUseCase {
+    private final TokenDeleteService tokenDeleteService;
+    private final TokenQueryService tokenQueryService;
+
+    public void logoutAccessUser(String refreshTokenHeader) {
+        final String refreshToken = TokenExtractUtils.extractToken(refreshTokenHeader);
+        final Token refreshTokenEntity = tokenQueryService.findTokenByValue(refreshToken, TokenType.REFRESH_TOKEN);
+        tokenDeleteService.deleteToken(refreshTokenEntity);
+    }
+
+}

--- a/core-module/src/main/java/com/koa/coremodule/auth/domain/entity/Token.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/domain/entity/Token.java
@@ -7,11 +7,15 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Builder
 @Entity
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE token SET deleted = true WHERE token_id = ?")
+@Where(clause = "deleted = false")
 @Getter
 public class Token extends BaseEntity {
     @Id
@@ -25,7 +29,5 @@ public class Token extends BaseEntity {
     private String email;
     private String value;
 
-    public static Token createToken(TokenType type, String email, String value){
-        return new Token(null, type, email, value);
-    }
+    private Boolean deleted = Boolean.FALSE;
 }

--- a/core-module/src/main/java/com/koa/coremodule/auth/domain/entity/Token.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/domain/entity/Token.java
@@ -27,7 +27,7 @@ public class Token extends BaseEntity {
     private TokenType tokenType;
 
     private String email;
-    private String value;
+    private String tokenValue;
 
     private Boolean deleted = Boolean.FALSE;
 }

--- a/core-module/src/main/java/com/koa/coremodule/auth/domain/entity/Token.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/domain/entity/Token.java
@@ -4,9 +4,11 @@ import com.koa.commonmodule.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Builder
 @Entity
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -21,7 +23,7 @@ public class Token extends BaseEntity {
     private TokenType tokenType;
 
     private String email;
-    private String tokenValue;
+    private String value;
 
     public static Token createToken(TokenType type, String email, String value){
         return new Token(null, type, email, value);

--- a/core-module/src/main/java/com/koa/coremodule/auth/domain/jwt/JWTProvider.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/domain/jwt/JWTProvider.java
@@ -62,8 +62,8 @@ public class JWTProvider {
         Date expireDate = getExpiration(refreshToken);
         Date currentDate = new Date();
         if (expireDate.getTime() - currentDate.getTime() < jwtProperties.getReissueRefreshTokenExpirationTime()) {
+            tokenDeleteService.deleteTokenByValue(refreshToken);
             final String email = extractEmailFromRefreshToken(refreshToken);
-            tokenDeleteService.deleteToken(email);
             return generateRefreshToken(email);
         }
         else return refreshToken;
@@ -86,7 +86,7 @@ public class JWTProvider {
      *
      */
     private String extractEmailFromRefreshToken(String refreshToken) {
-        final String email = tokenQueryService.findEmailByToken(refreshToken, TokenType.REFRESH_TOKEN);
+        final String email = tokenQueryService.findEmailByValue(refreshToken, TokenType.REFRESH_TOKEN);
         return email;
     }
 

--- a/core-module/src/main/java/com/koa/coremodule/auth/domain/jwt/JWTProvider.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/domain/jwt/JWTProvider.java
@@ -62,7 +62,7 @@ public class JWTProvider {
         Date expireDate = getExpiration(refreshToken);
         Date currentDate = new Date();
         if (expireDate.getTime() - currentDate.getTime() < jwtProperties.getReissueRefreshTokenExpirationTime()) {
-            tokenDeleteService.deleteTokenByValue(refreshToken);
+            tokenDeleteService.deleteTokenByTokenValue(refreshToken);
             final String email = extractEmailFromRefreshToken(refreshToken);
             return generateRefreshToken(email);
         }

--- a/core-module/src/main/java/com/koa/coremodule/auth/domain/repository/TokenRepository.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/domain/repository/TokenRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface TokenRepository extends JpaRepository<Token, Long> {
-    Optional<Token> findByValueAndTokenType(String email, TokenType tokenType);
-    void deleteByValue(String value);
+    Optional<Token> findByTokenValueAndTokenType(String value, TokenType tokenType);
+    Optional<Token> findByEmailAndTokenType(String email, TokenType tokenType);
+    void deleteByTokenValue(String value);
 }

--- a/core-module/src/main/java/com/koa/coremodule/auth/domain/repository/TokenRepository.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/domain/repository/TokenRepository.java
@@ -7,6 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface TokenRepository extends JpaRepository<Token, Long> {
-    Optional<Token> findByTokenValueAndTokenType(String email, TokenType tokenType);
-    void deleteByEmail(String email);
+    Optional<Token> findByValueAndTokenType(String email, TokenType tokenType);
+    void deleteByValue(String value);
 }

--- a/core-module/src/main/java/com/koa/coremodule/auth/domain/service/TokenDeleteService.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/domain/service/TokenDeleteService.java
@@ -11,8 +11,8 @@ import lombok.RequiredArgsConstructor;
 @Transactional
 public class TokenDeleteService {
     private final TokenRepository tokenRepository;
-    public void deleteTokenByValue(String value) {
-        tokenRepository.deleteByValue(value);
+    public void deleteTokenByTokenValue(String value) {
+        tokenRepository.deleteByTokenValue(value);
     }
 
     public void deleteToken(final Token token){

--- a/core-module/src/main/java/com/koa/coremodule/auth/domain/service/TokenDeleteService.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/domain/service/TokenDeleteService.java
@@ -1,6 +1,7 @@
 package com.koa.coremodule.auth.domain.service;
 
 import com.koa.commonmodule.annotation.DomainService;
+import com.koa.coremodule.auth.domain.entity.Token;
 import com.koa.coremodule.auth.domain.repository.TokenRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -13,4 +14,9 @@ public class TokenDeleteService {
     public void deleteToken(final String email){
         tokenRepository.deleteByEmail(email);
     }
+
+    public void deleteToken(final Token token){
+        tokenRepository.delete(token);
+    }
+
 }

--- a/core-module/src/main/java/com/koa/coremodule/auth/domain/service/TokenDeleteService.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/domain/service/TokenDeleteService.java
@@ -11,8 +11,8 @@ import lombok.RequiredArgsConstructor;
 @Transactional
 public class TokenDeleteService {
     private final TokenRepository tokenRepository;
-    public void deleteToken(final String email){
-        tokenRepository.deleteByEmail(email);
+    public void deleteTokenByValue(String value) {
+        tokenRepository.deleteByValue(value);
     }
 
     public void deleteToken(final Token token){

--- a/core-module/src/main/java/com/koa/coremodule/auth/domain/service/TokenQueryService.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/domain/service/TokenQueryService.java
@@ -14,9 +14,17 @@ public class TokenQueryService {
 
     private final TokenRepository tokenRepository;
 
-    public String findEmailByToken(final String value, final TokenType tokenType) {
-        Token token = tokenRepository.findByTokenValueAndTokenType(value, tokenType)
-                .orElseThrow(() -> new NotExistTokenException(Error.NOT_EXIST_TOKEN));
+    public String findEmailByValue(final String value, final TokenType tokenType) {
+        Token token = findToken(value, tokenType);
         return token.getEmail();
+    }
+
+    public Token findTokenByValue(String value, TokenType tokenType) {
+        return findToken(value, tokenType);
+    }
+
+    private Token findToken(final String value, final TokenType tokenType){
+        return tokenRepository.findByValueAndTokenType(value, tokenType)
+                .orElseThrow(() -> new NotExistTokenException(Error.NOT_EXIST_TOKEN));
     }
 }

--- a/core-module/src/main/java/com/koa/coremodule/auth/domain/service/TokenQueryService.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/domain/service/TokenQueryService.java
@@ -15,16 +15,14 @@ public class TokenQueryService {
     private final TokenRepository tokenRepository;
 
     public String findEmailByValue(final String value, final TokenType tokenType) {
-        Token token = findToken(value, tokenType);
+        Token token = tokenRepository.findByEmailAndTokenType(value, tokenType)
+                .orElseThrow(() -> new NotExistTokenException(Error.NOT_EXIST_TOKEN));
         return token.getEmail();
     }
 
-    public Token findTokenByValue(String value, TokenType tokenType) {
-        return findToken(value, tokenType);
-    }
-
-    private Token findToken(final String value, final TokenType tokenType){
-        return tokenRepository.findByValueAndTokenType(value, tokenType)
+    public Token findTokenByTokenValue(String value, TokenType tokenType) {
+        Token token = tokenRepository.findByTokenValueAndTokenType(value, tokenType)
                 .orElseThrow(() -> new NotExistTokenException(Error.NOT_EXIST_TOKEN));
+        return token;
     }
 }

--- a/core-module/src/main/java/com/koa/coremodule/auth/domain/service/TokenSaveService.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/domain/service/TokenSaveService.java
@@ -11,6 +11,10 @@ import lombok.RequiredArgsConstructor;
 public class TokenSaveService {
     private final TokenRepository tokenRepository;
     public void saveToken( final String token, final String email, final TokenType tokenType){
-        tokenRepository.save(Token.createToken(tokenType, email, token));
+        tokenRepository.save(Token.builder()
+                .tokenType(tokenType)
+                .value(token)
+                .email(email)
+                .build());
     }
 }

--- a/core-module/src/main/java/com/koa/coremodule/auth/domain/service/TokenSaveService.java
+++ b/core-module/src/main/java/com/koa/coremodule/auth/domain/service/TokenSaveService.java
@@ -13,7 +13,7 @@ public class TokenSaveService {
     public void saveToken( final String token, final String email, final TokenType tokenType){
         tokenRepository.save(Token.builder()
                 .tokenType(tokenType)
-                .value(token)
+                .tokenValue(token)
                 .email(email)
                 .build());
     }

--- a/core-module/src/main/java/com/koa/coremodule/email/config/EmailConfig.java
+++ b/core-module/src/main/java/com/koa/coremodule/email/config/EmailConfig.java
@@ -1,0 +1,70 @@
+package com.koa.coremodule.email.config;
+
+import java.util.Properties;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+@Configuration
+@RequiredArgsConstructor
+public class EmailConfig {
+
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttlsEnable;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.required}")
+    private boolean starttlsRequired;
+
+    @Value("${spring.mail.properties.mail.smtp.connectiontimeout}")
+    private int connectionTimeout;
+
+    @Value("${spring.mail.properties.mail.smtp.timeout}")
+    private int timeout;
+
+    @Value("${spring.mail.properties.mail.smtp.writetimeout}")
+    private int writeTimeout;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+        mailSender.setDefaultEncoding("UTF-8");
+        mailSender.setJavaMailProperties(getMailProperties());
+
+        return mailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+        properties.put("mail.smtp.auth", auth);
+        properties.put("mail.smtp.starttls.enable", starttlsEnable);
+        properties.put("mail.smtp.starttls.required", starttlsRequired);
+        properties.put("mail.smtp.connectiontimeout", connectionTimeout);
+        properties.put("mail.smtp.timeout", timeout);
+        properties.put("mail.smtp.writetimeout", writeTimeout);
+
+        return properties;
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/email/exception/CreateCodeException.java
+++ b/core-module/src/main/java/com/koa/coremodule/email/exception/CreateCodeException.java
@@ -1,0 +1,8 @@
+package com.koa.coremodule.email.exception;
+import com.koa.commonmodule.exception.Error;
+
+public class CreateCodeException extends EmailException{
+    public CreateCodeException(Error error) {
+        super(error);
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/email/exception/EmailException.java
+++ b/core-module/src/main/java/com/koa/coremodule/email/exception/EmailException.java
@@ -1,0 +1,10 @@
+package com.koa.coremodule.email.exception;
+
+import com.koa.commonmodule.exception.BusinessException;
+import com.koa.commonmodule.exception.Error;
+
+public class EmailException extends BusinessException {
+    public EmailException(Error error) {
+        super(error);
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/email/exception/WrongCodeException.java
+++ b/core-module/src/main/java/com/koa/coremodule/email/exception/WrongCodeException.java
@@ -1,0 +1,8 @@
+package com.koa.coremodule.email.exception;
+import com.koa.commonmodule.exception.Error;
+
+public class WrongCodeException extends EmailException{
+    public WrongCodeException(Error error) {
+        super(error);
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/email/service/EmailSendService.java
+++ b/core-module/src/main/java/com/koa/coremodule/email/service/EmailSendService.java
@@ -1,0 +1,57 @@
+package com.koa.coremodule.email.service;
+
+import com.koa.commonmodule.exception.Error;
+import com.koa.commonmodule.utils.RedisUtils;
+import com.koa.coremodule.email.exception.CreateCodeException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Random;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmailSendService {
+    private static final int LENGTH = 6;
+    private static final String MESSAGE= "인증번호는 %s 입니다.";
+    private static final String TITLE = "KOA 이메일 인증";
+    private final JavaMailSender emailSender;
+    private final RedisUtils redisUtils;
+
+    @Value("${spring.mail.auth-code-expiration-millis}")
+    private long authCodeExpirationMillis;
+
+    public void sendEmail(String email) {
+        String code = createCode();
+        SimpleMailMessage emailForm = createEmailForm(email, TITLE, String.format(MESSAGE, code));
+        emailSender.send(emailForm);
+        redisUtils.setDataExpire(email, code, authCodeExpirationMillis);
+    }
+
+    private String createCode() {
+        try {
+            Random random = SecureRandom.getInstanceStrong();
+            StringBuilder builder = new StringBuilder();
+            for (int i = 0; i < LENGTH; i++) {
+                builder.append(random.nextInt(10));
+            }
+            return builder.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new CreateCodeException(Error.CREATE_CODE_FAIL);
+        }
+    }
+
+    private SimpleMailMessage createEmailForm(String toEmail,
+                                              String title,
+                                              String text) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(toEmail);
+        message.setSubject(title);
+        message.setText(text);
+
+        return message;
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/email/service/EmailVerifyService.java
+++ b/core-module/src/main/java/com/koa/coremodule/email/service/EmailVerifyService.java
@@ -1,0 +1,21 @@
+package com.koa.coremodule.email.service;
+
+import com.koa.commonmodule.exception.Error;
+import com.koa.commonmodule.utils.RedisUtils;
+import com.koa.coremodule.email.exception.WrongCodeException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmailVerifyService {
+
+    private final RedisUtils redisUtils;
+
+    public void verifyCode(String email, String code) {
+        String savedCode = redisUtils.getData(email);
+        if (!code.equals(savedCode)) {
+            throw new WrongCodeException(Error.WRONG_CODE);
+        }
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/image/config/AwsS3Config.java
+++ b/core-module/src/main/java/com/koa/coremodule/image/config/AwsS3Config.java
@@ -1,4 +1,4 @@
-package com.koa.commonmodule.config;
+package com.koa.coremodule.image.config;
 
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;

--- a/core-module/src/main/java/com/koa/coremodule/member/application/service/EmailVerificationUseCase.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/application/service/EmailVerificationUseCase.java
@@ -1,0 +1,25 @@
+package com.koa.coremodule.member.application.service;
+
+import com.koa.commonmodule.annotation.ApplicationService;
+import com.koa.coremodule.email.service.EmailSendService;
+import com.koa.coremodule.email.service.EmailVerifyService;
+import com.koa.coremodule.member.domain.service.MemberQueryService;
+import lombok.RequiredArgsConstructor;
+
+@ApplicationService
+@RequiredArgsConstructor
+public class EmailVerificationUseCase {
+
+    private final EmailSendService emailSendService;
+    private final EmailVerifyService emailVerifyService;
+    private final MemberQueryService memberQueryService;
+
+    public void sendVerificationEmail(String email) {
+        memberQueryService.checkEmailExist(email);
+        emailSendService.sendEmail(email);
+    }
+
+    public void verifyCode(String email, String code) {
+        emailVerifyService.verifyCode(email, code);
+    }
+}

--- a/core-module/src/main/java/com/koa/coremodule/member/domain/repository/MemberRepository.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/domain/repository/MemberRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmailAndAuthority(String email, Authority authority);
     boolean existsByEmailAndPassword(String email, String password);
+    boolean existsByEmail(String email);
 
     Optional<Member> findByEmail(String email);
 }

--- a/core-module/src/main/java/com/koa/coremodule/member/domain/service/MemberQueryService.java
+++ b/core-module/src/main/java/com/koa/coremodule/member/domain/service/MemberQueryService.java
@@ -29,4 +29,10 @@ public class MemberQueryService {
         return memberRepository.findByEmail(email)
                 .orElseThrow(() -> new UserNotFoundException(Error.MEMBER_NOT_FOUND));
     }
+
+    public void checkEmailExist(String email) {
+        if(memberRepository.existsByEmail(email) == false) {
+            throw new UserNotFoundException(Error.MEMBER_NOT_FOUND);
+        }
+    }
 }


### PR DESCRIPTION
- 이메일 인증 기능, 로그아웃 기능 추가했습니다.
- 토큰 재발급 API 검증 무시하게끔 처리했습니다. 
- 로그아웃 시, Token soft delete하도록 처리했습니다.
- 통일성을 위해 Token엔티티에서 Builder를 사용하도록 수정했습니다. 